### PR TITLE
Fix for #4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.flipkart.ranger</groupId>
     <artifactId>ranger</artifactId>
     <packaging>jar</packaging>
-    <version>0.2</version>
+    <version>0.2.1-SNAPSHOT</version>
 
     <distributionManagement>
         <repository>
@@ -93,6 +93,11 @@
             <version>4.12</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.rholder</groupId>
+            <artifactId>guava-retrying</artifactId>
+            <version>2.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/flipkart/ranger/healthcheck/HealthChecker.java
+++ b/src/main/java/com/flipkart/ranger/healthcheck/HealthChecker.java
@@ -38,7 +38,12 @@ public class HealthChecker<T> implements Runnable {
     public void run() {
         HealthcheckStatus healthcheckStatus = HealthcheckStatus.unhealthy;
         for(Healthcheck healthcheck : healthchecks) {
-            healthcheckStatus = healthcheck.check();
+            try {
+                healthcheckStatus = healthcheck.check();
+            } catch (Throwable t) {
+                logger.error("Error running healthcheck. Setting node to unhealthy");
+                healthcheckStatus = HealthcheckStatus.unhealthy;
+            }
             if(HealthcheckStatus.unhealthy == healthcheckStatus) {
                 break;
             }

--- a/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProvider.java
+++ b/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProvider.java
@@ -92,7 +92,7 @@ public class ServiceProvider<T> {
                 .retryIfExceptionOfType(KeeperException.NodeExistsException.class) //Ephimeral node still exists
                 .withWaitStrategy(WaitStrategies.fixedWait(1, TimeUnit.SECONDS))
                 .withBlockStrategy(BlockStrategies.threadSleepStrategy())
-                .withStopStrategy(StopStrategies.stopAfterAttempt(60))
+                .withStopStrategy(StopStrategies.neverStop())
                 .build();
         try {
             retryer.call(new Callable<Void>() {


### PR DESCRIPTION
1) Uses guava reties to retry for a minute at 1 sec intervals if the create() method is throwing NodeExists exception. All othe exceptions are forwarded and retry stops.
2) Catches exception in running healthchecks and returns unhealthy