### PR TITLE
The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/com/flipkart/ranger/healthservice/TimeEntity.java
+++ b/src/main/java/com/flipkart/ranger/healthservice/TimeEntity.java
@@ -9,6 +9,31 @@ import java.util.concurrent.TimeUnit;
  */
 public class TimeEntity {
 
+    private long initialDelay;
+    private long timeInterval;
+    private TimeUnit timeUnit;
+
+    /**
+     * defaults initial delay to 0 timeunits
+     *
+     * @param timeInterval repeat time interval of task
+     * @param timeUnit     unit of time, for tracking the interval
+     */
+    public TimeEntity(long timeInterval, TimeUnit timeUnit) {
+        this(0, timeInterval, timeUnit);
+    }
+    
+    /**
+     * @param initialDelay initial delay for triggering the task
+     * @param timeInterval repeat time interval of task
+     * @param timeUnit     unit of time, for tracking the interval
+     */
+    public TimeEntity(long initialDelay, long timeInterval, TimeUnit timeUnit) {
+        this.initialDelay = initialDelay;
+        this.timeInterval = timeInterval;
+        this.timeUnit = timeUnit;
+    }
+    
     /**
      * @return a TimeEntity with time interval of every second
      */
@@ -35,31 +60,6 @@ public class TimeEntity {
      */
     public static TimeEntity EveryDay() {
         return new TimeEntity(0, 1, TimeUnit.DAYS);
-    }
-
-    private long initialDelay;
-    private long timeInterval;
-    private TimeUnit timeUnit;
-
-    /**
-     * defaults initial delay to 0 timeunits
-     *
-     * @param timeInterval repeat time interval of task
-     * @param timeUnit     unit of time, for tracking the interval
-     */
-    public TimeEntity(long timeInterval, TimeUnit timeUnit) {
-        this(0, timeInterval, timeUnit);
-    }
-
-    /**
-     * @param initialDelay initial delay for triggering the task
-     * @param timeInterval repeat time interval of task
-     * @param timeUnit     unit of time, for tracking the interval
-     */
-    public TimeEntity(long initialDelay, long timeInterval, TimeUnit timeUnit) {
-        this.initialDelay = initialDelay;
-        this.timeInterval = timeInterval;
-        this.timeUnit = timeUnit;
     }
 
     public long getTimeInterval() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1213  The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Zeeshan Asghar