### PR TITLE
General Code Improvement 2

### DIFF
--- a/src/main/java/com/flipkart/ranger/ServiceFinderBuilders.java
+++ b/src/main/java/com/flipkart/ranger/ServiceFinderBuilders.java
@@ -20,6 +20,11 @@ import com.flipkart.ranger.finder.sharded.SimpleShardedServiceFinderBuilder;
 import com.flipkart.ranger.finder.unsharded.UnshardedFinderBuilder;
 
 public class ServiceFinderBuilders {
+    
+    private ServiceFinderBuilders() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+    
     public static <T> SimpleShardedServiceFinderBuilder<T> shardedFinderBuilder() {
         return new SimpleShardedServiceFinderBuilder<T>();
     }

--- a/src/main/java/com/flipkart/ranger/ServiceProviderBuilders.java
+++ b/src/main/java/com/flipkart/ranger/ServiceProviderBuilders.java
@@ -20,6 +20,11 @@ import com.flipkart.ranger.finder.unsharded.UnshardedClusterInfo;
 import com.flipkart.ranger.serviceprovider.ServiceProviderBuilder;
 
 public class ServiceProviderBuilders {
+    
+    private ServiceProviderBuilders() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+    
     public static <T> ServiceProviderBuilder<T> shardedServiceProviderBuilder() {
         return new ServiceProviderBuilder<T>();
     }

--- a/src/main/java/com/flipkart/ranger/finder/ServiceRegistryUpdater.java
+++ b/src/main/java/com/flipkart/ranger/finder/ServiceRegistryUpdater.java
@@ -63,6 +63,8 @@ public class ServiceRegistryUpdater<T> implements Callable<Void> {
                     case NodeDeleted:
                     case NodeDataChanged:
                         break;
+                    default:
+                        break;
                 }
             }
         }).forPath(PathBuilder.path(serviceRegistry.getService())); //Start watcher on service node

--- a/src/main/java/com/flipkart/ranger/healthservice/monitor/Monitors.java
+++ b/src/main/java/com/flipkart/ranger/healthservice/monitor/Monitors.java
@@ -11,6 +11,10 @@ import java.io.File;
  */
 public class Monitors {
 
+    private Monitors() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+    
     public static Monitor<HealthcheckStatus> fileExistanceCheckMonitor(final String filePath) {
         return new Monitor<HealthcheckStatus>() {
             @Override

--- a/src/main/java/com/flipkart/ranger/model/PathBuilder.java
+++ b/src/main/java/com/flipkart/ranger/model/PathBuilder.java
@@ -19,6 +19,11 @@ package com.flipkart.ranger.model;
 import com.flipkart.ranger.finder.Service;
 
 public class PathBuilder {
+    
+    private PathBuilder() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+    
     public static String path(final Service service) {
         return String.format("/%s", service.getServiceName());
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1118 Utility classes should not have public constructors
squid:SwitchLastCaseIsDefaultCheck  'switch' statements should end with a 'default' clause'

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

Zeeshan Asghar