### PR TITLE
Conditional health status update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
-  - oraclejdk9
+  - openjdk8
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Use the following maven dependency:
 <dependency>
     <groupId>com.flipkart.ranger</groupId>
     <artifactId>ranger</artifactId>
-    <version>0.4.1</version>
+    <version>0.6</version>
 </dependency>
 ```
 ## How it works

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.flipkart.ranger</groupId>
     <artifactId>ranger</artifactId>
     <packaging>jar</packaging>
-    <version>0.5</version>
+    <version>0.6</version>
 
     <distributionManagement>
         <repository>

--- a/src/main/java/com/flipkart/ranger/healthcheck/HealthChecker.java
+++ b/src/main/java/com/flipkart/ranger/healthcheck/HealthChecker.java
@@ -59,10 +59,11 @@ public class HealthChecker<T> implements Runnable {
         //1. First time
         //2. Stale update threshold breach
         //3. Update in health status
+        long currentTime = System.currentTimeMillis();
         if(lastHealthcheckStatus == null ||
-            (System.currentTimeMillis() - lastUpdatedTime) > serviceProvider.getStaleUpdateThreshold()
+            (currentTime - lastUpdatedTime) > serviceProvider.getStaleUpdateThreshold()
                 || lastHealthcheckStatus != healthcheckStatus) {
-            lastUpdatedTime = System.currentTimeMillis();
+            lastUpdatedTime = currentTime;
             ServiceNode<T> serviceNode = serviceProvider.getServiceNode();
             serviceNode.setHealthcheckStatus(healthcheckStatus);
             serviceNode.setLastUpdatedTimeStamp(lastUpdatedTime);

--- a/src/main/java/com/flipkart/ranger/healthcheck/HealthChecker.java
+++ b/src/main/java/com/flipkart/ranger/healthcheck/HealthChecker.java
@@ -32,6 +32,8 @@ public class HealthChecker<T> implements Runnable {
 
     private List<Healthcheck> healthchecks;
     private ServiceProvider<T> serviceProvider;
+    private HealthcheckStatus lastHealthcheckStatus;
+    private long lastUpdatedTime;
 
     public HealthChecker(List<Healthcheck> healthchecks, ServiceProvider<T> serviceProvider) {
         this.healthchecks = healthchecks;
@@ -52,15 +54,26 @@ public class HealthChecker<T> implements Runnable {
                 break;
             }
         }
-        ServiceNode<T> serviceNode = serviceProvider.getServiceNode();
-        serviceNode.setHealthcheckStatus(healthcheckStatus);
-        serviceNode.setLastUpdatedTimeStamp(System.currentTimeMillis());
-        try {
-            serviceProvider.updateState(serviceNode);
-            logger.debug("Node is {} for ({}, {})",
-                                        healthcheckStatus.name(), serviceNode.getHost(), serviceNode.getPort());
-        } catch (Exception e) {
-            logger.error("Error updating health state in zookeeper: ", e);
+        //Trigger update only if state change has happened
+        //Conditions on which update will be triggered
+        //1. First time
+        //2. Stale update threshold breach
+        //3. Update in health status
+        if(lastHealthcheckStatus == null ||
+            (System.currentTimeMillis() - lastUpdatedTime) > serviceProvider.getStaleUpdateThreshold()
+                || lastHealthcheckStatus != healthcheckStatus) {
+            lastUpdatedTime = System.currentTimeMillis();
+            ServiceNode<T> serviceNode = serviceProvider.getServiceNode();
+            serviceNode.setHealthcheckStatus(healthcheckStatus);
+            serviceNode.setLastUpdatedTimeStamp(lastUpdatedTime);
+            try {
+                serviceProvider.updateState(serviceNode);
+                logger.debug("Node is {} for ({}, {})",
+                    healthcheckStatus.name(), serviceNode.getHost(), serviceNode.getPort());
+            } catch (Exception e) {
+                logger.error("Error updating health state in zookeeper: ", e);
+            }
         }
+        lastHealthcheckStatus = healthcheckStatus;
     }
 }

--- a/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProvider.java
+++ b/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProvider.java
@@ -47,6 +47,7 @@ public class ServiceProvider<T> {
     private ServiceNode<T> serviceNode;
     private List<Healthcheck> healthchecks;
     private final int healthUpdateInterval;
+    private final int staleUpdateThreshold;
     private ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
     private ScheduledFuture<?> future;
     private ServiceHealthAggregator serviceHealthAggregator;
@@ -56,6 +57,7 @@ public class ServiceProvider<T> {
                            CuratorFramework curatorFramework,
                            ServiceNode<T> serviceNode,
                            List<Healthcheck> healthchecks, int healthUpdateInterval,
+                           int staleUpdateThreshold,
                            ServiceHealthAggregator serviceHealthAggregator) {
         this.serviceName = serviceName;
         this.serializer = serializer;
@@ -63,6 +65,7 @@ public class ServiceProvider<T> {
         this.serviceNode = serviceNode;
         this.healthchecks = healthchecks;
         this.healthUpdateInterval = healthUpdateInterval;
+        this.staleUpdateThreshold = staleUpdateThreshold;
         this.serviceHealthAggregator = serviceHealthAggregator;
     }
 
@@ -101,7 +104,7 @@ public class ServiceProvider<T> {
 
     public int getStaleUpdateThreshold() {
         //Reduce it by 100ms to make sure we do not overrun the stale check on client which will ignore the service node instance
-        return healthUpdateInterval - 100;
+        return staleUpdateThreshold;
     }
 
     private void createPath() throws Exception {

--- a/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProvider.java
+++ b/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProvider.java
@@ -47,7 +47,6 @@ public class ServiceProvider<T> {
     private ServiceNode<T> serviceNode;
     private List<Healthcheck> healthchecks;
     private final int healthUpdateInterval;
-    private final int staleUpdateThreshold;
     private ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
     private ScheduledFuture<?> future;
     private ServiceHealthAggregator serviceHealthAggregator;
@@ -56,7 +55,7 @@ public class ServiceProvider<T> {
     public ServiceProvider(String serviceName, Serializer<T> serializer,
                            CuratorFramework curatorFramework,
                            ServiceNode<T> serviceNode,
-                           List<Healthcheck> healthchecks, int healthUpdateInterval, int staleUpdateThreshold,
+                           List<Healthcheck> healthchecks, int healthUpdateInterval,
                            ServiceHealthAggregator serviceHealthAggregator) {
         this.serviceName = serviceName;
         this.serializer = serializer;
@@ -64,7 +63,6 @@ public class ServiceProvider<T> {
         this.serviceNode = serviceNode;
         this.healthchecks = healthchecks;
         this.healthUpdateInterval = healthUpdateInterval;
-        this.staleUpdateThreshold = staleUpdateThreshold;
         this.serviceHealthAggregator = serviceHealthAggregator;
     }
 
@@ -103,7 +101,7 @@ public class ServiceProvider<T> {
 
     public int getStaleUpdateThreshold() {
         //Reduce it by 100ms to make sure we do not overrun the stale check on client which will ignore the service node instance
-        return staleUpdateThreshold - 100;
+        return healthUpdateInterval - 100;
     }
 
     private void createPath() throws Exception {

--- a/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProvider.java
+++ b/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProvider.java
@@ -103,7 +103,6 @@ public class ServiceProvider<T> {
     }
 
     public int getStaleUpdateThreshold() {
-        //Reduce it by 100ms to make sure we do not overrun the stale check on client which will ignore the service node instance
         return staleUpdateThreshold;
     }
 

--- a/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProviderBuilder.java
+++ b/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProviderBuilder.java
@@ -44,7 +44,6 @@ public class ServiceProviderBuilder<T> {
     private int port;
     private T nodeData;
     private int healthUpdateIntervalMs;
-    private int staleUpdateThresholdMs;
     private List<Healthcheck> healthchecks = Lists.newArrayList();
 
     /* list of isolated monitors */
@@ -100,10 +99,6 @@ public class ServiceProviderBuilder<T> {
         return this;
     }
 
-    public ServiceProviderBuilder<T> withStaleUpdateThresholdMs(int staleUpdateThresholdMs) {
-        this.staleUpdateThresholdMs = staleUpdateThresholdMs;
-        return this;
-    }
 
     /**
      * Register a monitor to the service, to setup a continuous monitoring on the monitor
@@ -138,10 +133,6 @@ public class ServiceProviderBuilder<T> {
             LOGGER.warn("Health update interval too low: {} ms. Has been upgraded to 1000ms ", healthUpdateIntervalMs);
             healthUpdateIntervalMs = 1000;
         }
-        if (staleUpdateThresholdMs < 1000) {
-            LOGGER.warn("Stale update too too low: {} ms. Has been upgraded to 60000ms ", staleUpdateThresholdMs);
-            staleUpdateThresholdMs = 60000;
-        }
 
         final ServiceHealthAggregator serviceHealthAggregator = new ServiceHealthAggregator();
         for (IsolatedHealthMonitor isolatedMonitor : isolatedMonitors) {
@@ -150,7 +141,7 @@ public class ServiceProviderBuilder<T> {
         healthchecks.add(serviceHealthAggregator);
         return new ServiceProvider<>(serviceName, serializer, curatorFramework,
                                      new ServiceNode<>(hostname, port, nodeData), healthchecks,
-                                     healthUpdateIntervalMs, staleUpdateThresholdMs, serviceHealthAggregator);
+                                     healthUpdateIntervalMs, serviceHealthAggregator);
     }
 
 }

--- a/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProviderBuilder.java
+++ b/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProviderBuilder.java
@@ -129,9 +129,9 @@ public class ServiceProviderBuilder<T> {
                     .retryPolicy(new ExponentialBackoffRetry(1000, 100)).build();
             curatorFramework.start();
         }
-        if (healthUpdateIntervalMs < 1000) {
-            LOGGER.warn("Health update interval too low: {} ms. Has been upgraded to 1000ms ", healthUpdateIntervalMs);
-            healthUpdateIntervalMs = 1000;
+        if (healthUpdateIntervalMs < 1000 || healthUpdateIntervalMs > 60000) {
+            LOGGER.warn("Health update interval too low: {} ms. Has been upgraded to 60000ms ", healthUpdateIntervalMs);
+            healthUpdateIntervalMs = 60000;
         }
 
         final ServiceHealthAggregator serviceHealthAggregator = new ServiceHealthAggregator();

--- a/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProviderBuilder.java
+++ b/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProviderBuilder.java
@@ -140,7 +140,8 @@ public class ServiceProviderBuilder<T> {
             healthUpdateIntervalMs = 3000;
         }
         if (staleUpdateThresholdMs < 1000 || staleUpdateThresholdMs > 45000) {
-            LOGGER.warn("Stale update too too low: {} ms. Has been upgraded to 45000ms ", staleUpdateThresholdMs);
+            LOGGER.warn("Stale update threshold should be between 1000ms and 45000ms. Current value: {} ms. " +
+                "Being set to 45000ms", staleUpdateThresholdMs);
             staleUpdateThresholdMs = 45000;
         }
         final ServiceHealthAggregator serviceHealthAggregator = new ServiceHealthAggregator();

--- a/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProviderBuilder.java
+++ b/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProviderBuilder.java
@@ -44,6 +44,7 @@ public class ServiceProviderBuilder<T> {
     private int port;
     private T nodeData;
     private int healthUpdateIntervalMs;
+    private int staleUpdateThresholdMs;
     private List<Healthcheck> healthchecks = Lists.newArrayList();
 
     /* list of isolated monitors */
@@ -99,6 +100,10 @@ public class ServiceProviderBuilder<T> {
         return this;
     }
 
+    public ServiceProviderBuilder<T> withStaleUpdateThresholdMs(int staleUpdateThresholdMs) {
+        this.staleUpdateThresholdMs = staleUpdateThresholdMs;
+        return this;
+    }
 
     /**
      * Register a monitor to the service, to setup a continuous monitoring on the monitor
@@ -129,11 +134,15 @@ public class ServiceProviderBuilder<T> {
                     .retryPolicy(new ExponentialBackoffRetry(1000, 100)).build();
             curatorFramework.start();
         }
-        if (healthUpdateIntervalMs < 1000 || healthUpdateIntervalMs > 60000) {
-            LOGGER.warn("Health update interval too low: {} ms. Has been upgraded to 60000ms ", healthUpdateIntervalMs);
-            healthUpdateIntervalMs = 60000;
+        if (healthUpdateIntervalMs < 3000 || healthUpdateIntervalMs > 60000) {
+            LOGGER.warn("Health update interval should be between 3000ms and 60000ms. Current value: {} ms. " +
+                "Being set to 3000ms", healthUpdateIntervalMs);
+            healthUpdateIntervalMs = 3000;
         }
-
+        if (staleUpdateThresholdMs < 1000 || staleUpdateThresholdMs > 45000) {
+            LOGGER.warn("Stale update too too low: {} ms. Has been upgraded to 45000ms ", staleUpdateThresholdMs);
+            staleUpdateThresholdMs = 45000;
+        }
         final ServiceHealthAggregator serviceHealthAggregator = new ServiceHealthAggregator();
         for (IsolatedHealthMonitor isolatedMonitor : isolatedMonitors) {
             serviceHealthAggregator.addIsolatedMonitor(isolatedMonitor);
@@ -141,7 +150,7 @@ public class ServiceProviderBuilder<T> {
         healthchecks.add(serviceHealthAggregator);
         return new ServiceProvider<>(serviceName, serializer, curatorFramework,
                                      new ServiceNode<>(hostname, port, nodeData), healthchecks,
-                                     healthUpdateIntervalMs, serviceHealthAggregator);
+                                     healthUpdateIntervalMs, staleUpdateThresholdMs, serviceHealthAggregator);
     }
 
 }

--- a/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProviderBuilder.java
+++ b/src/main/java/com/flipkart/ranger/serviceprovider/ServiceProviderBuilder.java
@@ -44,6 +44,7 @@ public class ServiceProviderBuilder<T> {
     private int port;
     private T nodeData;
     private int healthUpdateIntervalMs;
+    private int staleUpdateThresholdMs;
     private List<Healthcheck> healthchecks = Lists.newArrayList();
 
     /* list of isolated monitors */
@@ -99,6 +100,11 @@ public class ServiceProviderBuilder<T> {
         return this;
     }
 
+    public ServiceProviderBuilder<T> withStaleUpdateThresholdMs(int staleUpdateThresholdMs) {
+        this.staleUpdateThresholdMs = staleUpdateThresholdMs;
+        return this;
+    }
+
     /**
      * Register a monitor to the service, to setup a continuous monitoring on the monitor
      * this method can be used to add a {@link IsolatedHealthMonitor} which will later be
@@ -132,6 +138,11 @@ public class ServiceProviderBuilder<T> {
             LOGGER.warn("Health update interval too low: {} ms. Has been upgraded to 1000ms ", healthUpdateIntervalMs);
             healthUpdateIntervalMs = 1000;
         }
+        if (staleUpdateThresholdMs < 1000) {
+            LOGGER.warn("Stale update too too low: {} ms. Has been upgraded to 60000ms ", staleUpdateThresholdMs);
+            staleUpdateThresholdMs = 60000;
+        }
+
         final ServiceHealthAggregator serviceHealthAggregator = new ServiceHealthAggregator();
         for (IsolatedHealthMonitor isolatedMonitor : isolatedMonitors) {
             serviceHealthAggregator.addIsolatedMonitor(isolatedMonitor);
@@ -139,7 +150,7 @@ public class ServiceProviderBuilder<T> {
         healthchecks.add(serviceHealthAggregator);
         return new ServiceProvider<>(serviceName, serializer, curatorFramework,
                                      new ServiceNode<>(hostname, port, nodeData), healthchecks,
-                                     healthUpdateIntervalMs, serviceHealthAggregator);
+                                     healthUpdateIntervalMs, staleUpdateThresholdMs, serviceHealthAggregator);
     }
 
 }


### PR DESCRIPTION
Make health status update conditional and smart. This is reduce request flooding and breach outstanding request queue in case of massive micro services environment (100s of services with multiple dozen instances of each service running).
Update status only when there is a state change or has breached the staleUpdateThreshold (Which is set to dropwizardCheckStaleness - 100ms). 
Bacackwards compatibile with existing dependencies (dropwizard bundle) and will not break anything.