### PR TITLE
Directly reading node data from ZK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,13 +11,10 @@
 
     <distributionManagement>
         <repository>
-            <id>phonepe-releases</id>
-            <url>http://artifactory.phonepe.com/content/repositories/releases</url>
+            <id>clojars</id>
+            <name>Clojars repository</name>
+            <url>https://clojars.org/repo</url>
         </repository>
-        <snapshotRepository>
-            <id>phonepe-snapshots</id>
-            <url>http://artifactory.phonepe.com/content/repositories/snapshots</url>
-        </snapshotRepository>
     </distributionManagement>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,17 @@
     <groupId>com.flipkart.ranger</groupId>
     <artifactId>ranger</artifactId>
     <packaging>jar</packaging>
-    <version>0.6.1</version>
+    <version>0.6.2-SNAPSHOT</version>
 
     <distributionManagement>
         <repository>
-            <id>clojars</id>
-            <name>Clojars repository</name>
-            <url>https://clojars.org/repo</url>
+            <id>phonepe-releases</id>
+            <url>http://artifactory.phonepe.com/content/repositories/releases</url>
         </repository>
+        <snapshotRepository>
+            <id>phonepe-snapshots</id>
+            <url>http://artifactory.phonepe.com/content/repositories/snapshots</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <scm>

--- a/src/main/java/com/flipkart/ranger/finder/ServiceRegistryUpdater.java
+++ b/src/main/java/com/flipkart/ranger/finder/ServiceRegistryUpdater.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 Flipkart Internet Pvt. Ltd.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,7 +53,7 @@ public class ServiceRegistryUpdater<T> implements Callable<Void> {
 
     public void start() throws Exception {
         CuratorFramework curatorFramework = serviceRegistry.getService().getCuratorFramework();
-        if (!disableWatchers) {
+        if(!disableWatchers) {
             curatorFramework.getChildren()
                     .usingWatcher(new CuratorWatcher() {
                         @Override
@@ -89,7 +89,7 @@ public class ServiceRegistryUpdater<T> implements Callable<Void> {
                     checkCondition.await();
                 }
                 updateRegistry();
-                checkForUpdate = false;
+                checkForUpdate =false;
             } finally {
                 checkLock.unlock();
             }
@@ -111,7 +111,7 @@ public class ServiceRegistryUpdater<T> implements Callable<Void> {
             final long healthcheckZombieCheckThresholdTime = System.currentTimeMillis() - 60000; //1 Minute
             final Service service = serviceRegistry.getService();
             final String serviceName = service.getServiceName();
-            if (!service.isRunning()) {
+            if(!service.isRunning()) {
                 return Optional.empty();
             }
             final Deserializer<T> deserializer = serviceRegistry.getDeserializer();
@@ -121,7 +121,7 @@ public class ServiceRegistryUpdater<T> implements Callable<Void> {
             List<String> children = curatorFramework.getChildren().forPath(parentPath);
             List<ServiceNode<T>> nodes = Lists.newArrayListWithCapacity(children.size());
             logger.debug("Found {} nodes for [{}]", nodes.size(), serviceName);
-            for (String child : children) {
+            for(String child : children) {
                 final String path = String.format("%s/%s", parentPath, child);
                 try {
                     final byte[] data = curatorFramework.getData().forPath(path);
@@ -133,13 +133,16 @@ public class ServiceRegistryUpdater<T> implements Callable<Void> {
                     if (HealthcheckStatus.healthy == key.getHealthcheckStatus()) {
                         if (key.getLastUpdatedTimeStamp() > healthcheckZombieCheckThresholdTime) {
                             nodes.add(key);
-                        } else {
+                        }
+                        else {
                             logger.warn("Zombie node [{}:{}] found for [{}]", key.getHost(), key.getPort(), serviceName);
                         }
                     }
-                } catch (KeeperException.NoNodeException e) {
+                }
+                catch (KeeperException.NoNodeException e) {
                     logger.warn("Node not found for path {}", path);
-                } catch (Exception e) {
+                }
+                catch (Exception e) {
                     logger.error(String.format("Data fetch failed for path %s", path), e);
                 }
             }
@@ -157,11 +160,12 @@ public class ServiceRegistryUpdater<T> implements Callable<Void> {
 
     private void updateRegistry() {
         List<ServiceNode<T>> nodes = checkForUpdateOnZookeeper().orElse(null);
-        if (null != nodes) {
+        if(null != nodes) {
             logger.debug("Updating nodelist of size: {} for [{}]", nodes.size(),
                     serviceRegistry.getService().getServiceName());
             serviceRegistry.nodes(nodes);
-        } else {
+        }
+        else {
             logger.warn("No service shards/nodes found. We are disconnected from zookeeper. Keeping old list for {}",
                     serviceRegistry.getService().getServiceName());
         }


### PR DESCRIPTION
Current implementation in service registry updater first checks if a child node exists and then gets the actual data. While current implementation prevents any exception, it leads to twice the number of calls on zookeeper ensemble. In large infrastructure, this increases significant number of read calls on ZK. 